### PR TITLE
fix: flag typo naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ upon completion.
 By default, the Function is expected to be named `function.wasm` in the
 current directory. This may be overriden using the `-f` option.
 
-Example: `function-runner -s '../my-function-name.wasm' '../my-input.json'`
+Example: `function-runner -f '../my-function-name.wasm' '../my-input.json'`
 
 ## Commands (optional)
 


### PR DESCRIPTION
## What

Changed the example command in the readme to be using `-f` instead of `-s`.

## Why

With the naming change from `script` to `function`, the `--script` flag that is used to choose the Wasm binary to execute was changed to `--function`. Hence, the shortened version is now `-f` instead of `-s`.