### PR TITLE
chore: version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "function-runner"
-version = "0.2.3"
+version = "3.0.0"
 edition = "2021"
 
 [profile.test]


### PR DESCRIPTION
Bumped version to 3.0.0.

Bumped to a major version because renaming the project changed the flags (--function instead of --script) hence breaking.

Will follow-up with a release.