### PR TITLE
feat: structured error logging / propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "0.2.3"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "function-runner"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 
 [profile.test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,8 +6,8 @@ use std::{
 use wasmtime::{Engine, Linker, Module, Store};
 
 use crate::function_run_result::{
-    FunctionOutput::{self, InvalidOutput, JsonOutput},
-    FunctionRunResult,
+    FunctionOutput::{self, JsonInvalidOutput, JsonOutput},
+    FunctionRunResult, InvalidOutput,
 };
 
 pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResult> {
@@ -93,12 +93,13 @@ pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunRes
 
     let output: FunctionOutput = match serde_json::from_slice(&raw_output) {
         Ok(json_output) => JsonOutput(json_output),
-        Err(_) => InvalidOutput(
-            std::str::from_utf8(&raw_output)
+        Err(error) => JsonInvalidOutput(InvalidOutput {
+            output: std::str::from_utf8(&raw_output)
                 .map_err(|e| anyhow!("Couldn't print Function Output: {}", e))
                 .unwrap()
                 .to_owned(),
-        ),
+            error: error.to_string(),
+        }),
     };
 
     let name = function_path.file_name().unwrap().to_str().unwrap();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -25,7 +25,7 @@ pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunRes
 
     let runtime: Duration;
     let memory_usage: u64;
-    let mut error: Option<String> = Default::default();
+    let mut error: Option<String> = None;
 
     {
         let mut linker = Linker::new(&engine);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -142,9 +142,13 @@ mod tests {
         let function_run_result = run(
             Path::new("tests/benchmarks/stack_overflow.wasm").to_path_buf(),
             Path::new("tests/benchmarks/stack_overflow.json").to_path_buf(),
-        );
+        )
+        .unwrap();
 
-        assert!(function_run_result.is_err());
+        assert!(function_run_result
+            .error
+            .unwrap()
+            .contains("out of bounds memory access"));
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,7 @@ use std::{
 use wasmtime::{Engine, Linker, Module, Store};
 
 use crate::function_run_result::{
-    FunctionOutput::{self, JsonInvalidOutput, JsonOutput},
+    FunctionOutput::{self, InvalidJsonOutput, JsonOutput},
     FunctionRunResult, InvalidOutput,
 };
 
@@ -93,8 +93,8 @@ pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunRes
 
     let output: FunctionOutput = match serde_json::from_slice(&raw_output) {
         Ok(json_output) => JsonOutput(json_output),
-        Err(error) => JsonInvalidOutput(InvalidOutput {
-            output: std::str::from_utf8(&raw_output)
+        Err(error) => InvalidJsonOutput(InvalidOutput {
+            stdout: std::str::from_utf8(&raw_output)
                 .map_err(|e| anyhow!("Couldn't print Function Output: {}", e))
                 .unwrap()
                 .to_owned(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -91,18 +91,15 @@ pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunRes
         .expect("Output stream reference still exists")
         .into_inner();
 
-    let output: FunctionOutput;
-    match serde_json::from_slice(&raw_output) {
-        Ok(json_output) => output = JsonOutput(json_output),
-        Err(_) => {
-            output = InvalidOutput(
-                std::str::from_utf8(&raw_output)
-                    .map_err(|e| anyhow!("Couldn't print Function Output: {}", e))
-                    .unwrap()
-                    .to_owned(),
-            );
-        }
-    }
+    let output: FunctionOutput = match serde_json::from_slice(&raw_output) {
+        Ok(json_output) => JsonOutput(json_output),
+        Err(_) => InvalidOutput(
+            std::str::from_utf8(&raw_output)
+                .map_err(|e| anyhow!("Couldn't print Function Output: {}", e))
+                .unwrap()
+                .to_owned(),
+        ),
+    };
 
     let name = function_path.file_name().unwrap().to_str().unwrap();
     let size = function_path.metadata()?.len();

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -5,13 +5,13 @@ use std::{fmt, time::Duration};
 #[derive(Serialize, Deserialize)]
 pub struct InvalidOutput {
     pub error: String,
-    pub output: String,
+    pub stdout: String,
 }
 
 #[derive(Serialize, Deserialize)]
 pub enum FunctionOutput {
     JsonOutput(serde_json::Value),
-    JsonInvalidOutput(InvalidOutput),
+    InvalidJsonOutput(InvalidOutput),
 }
 
 #[derive(Serialize)]
@@ -76,12 +76,12 @@ impl fmt::Display for FunctionRunResult {
                         .unwrap_or_else(|error| error.to_string())
                 )?;
             }
-            FunctionOutput::JsonInvalidOutput(output) => {
+            FunctionOutput::InvalidJsonOutput(output) => {
                 writeln!(
                     formatter,
                     "{}\n\n{}",
                     "        Invalid Output      ".black().on_bright_red(),
-                    output.output
+                    output.stdout
                 )?;
 
                 writeln!(

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -76,19 +76,19 @@ impl fmt::Display for FunctionRunResult {
                         .unwrap_or_else(|error| error.to_string())
                 )?;
             }
-            FunctionOutput::InvalidJsonOutput(output) => {
+            FunctionOutput::InvalidJsonOutput(invalid_output) => {
                 writeln!(
                     formatter,
                     "{}\n\n{}",
                     "        Invalid Output      ".black().on_bright_red(),
-                    output.stdout
+                    invalid_output.stdout
                 )?;
 
                 writeln!(
                     formatter,
                     "{}\n\n{}",
                     "         JSON Error         ".black().on_bright_red(),
-                    output.error
+                    invalid_output.error
                 )?;
             }
         }

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -3,9 +3,15 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, time::Duration};
 
 #[derive(Serialize, Deserialize)]
+pub struct InvalidOutput {
+    pub error: String,
+    pub output: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub enum FunctionOutput {
     JsonOutput(serde_json::Value),
-    InvalidOutput(String),
+    JsonInvalidOutput(InvalidOutput),
 }
 
 #[derive(Serialize)]
@@ -70,12 +76,19 @@ impl fmt::Display for FunctionRunResult {
                         .unwrap_or_else(|error| error.to_string())
                 )?;
             }
-            FunctionOutput::InvalidOutput(output) => {
+            FunctionOutput::JsonInvalidOutput(output) => {
                 writeln!(
                     formatter,
                     "{}\n\n{}",
                     "        Invalid Output      ".black().on_bright_red(),
-                    output
+                    output.output
+                )?;
+
+                writeln!(
+                    formatter,
+                    "{}\n\n{}",
+                    "         JSON Error         ".black().on_bright_red(),
+                    output.error
                 )?;
             }
         }

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -10,6 +10,7 @@ pub struct FunctionRunResult {
     pub memory_usage: u64,
     pub logs: String,
     pub output: serde_json::Value,
+    pub error: Option<String>,
 }
 
 impl FunctionRunResult {
@@ -20,6 +21,7 @@ impl FunctionRunResult {
         memory_usage: u64,
         output: serde_json::Value,
         logs: String,
+        error: Option<String>,
     ) -> Self {
         FunctionRunResult {
             name,
@@ -28,6 +30,7 @@ impl FunctionRunResult {
             memory_usage,
             output,
             logs,
+            error,
         }
     }
 
@@ -44,6 +47,15 @@ impl fmt::Display for FunctionRunResult {
         writeln!(f, "Runtime: {:?}", self.runtime)?;
         writeln!(f, "Memory Usage: {}KB", self.memory_usage * 64)?;
         writeln!(f, "Size: {}KB\n", self.size / 1024)?;
+
+        if let Some(error) = &self.error {
+            writeln!(
+                f,
+                "{}\n\n{}",
+                "            Error             ".black().on_bright_red(),
+                error
+            )?;
+        }
 
         writeln!(
             f,

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -43,18 +43,18 @@ impl FunctionRunResult {
 }
 
 impl fmt::Display for FunctionRunResult {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let title = "      Benchmark Results      "
             .black()
             .on_truecolor(150, 191, 72);
-        write!(f, "{}\n\n", title)?;
-        writeln!(f, "Name: {}", self.name)?;
-        writeln!(f, "Runtime: {:?}", self.runtime)?;
-        writeln!(f, "Memory Usage: {}KB", self.memory_usage * 64)?;
-        writeln!(f, "Size: {}KB\n", self.size / 1024)?;
+        write!(formatter, "{}\n\n", title)?;
+        writeln!(formatter, "Name: {}", self.name)?;
+        writeln!(formatter, "Runtime: {:?}", self.runtime)?;
+        writeln!(formatter, "Memory Usage: {}KB", self.memory_usage * 64)?;
+        writeln!(formatter, "Size: {}KB\n", self.size / 1024)?;
 
         writeln!(
-            f,
+            formatter,
             "{}\n\n{}",
             "            Logs            ".black().on_bright_blue(),
             self.logs
@@ -63,7 +63,7 @@ impl fmt::Display for FunctionRunResult {
         match &self.output {
             FunctionOutput::JsonOutput(json_output) => {
                 writeln!(
-                    f,
+                    formatter,
                     "{}\n\n{}",
                     "           Output           ".black().on_bright_green(),
                     serde_json::to_string_pretty(&json_output)
@@ -72,7 +72,7 @@ impl fmt::Display for FunctionRunResult {
             }
             FunctionOutput::InvalidOutput(output) => {
                 writeln!(
-                    f,
+                    formatter,
                     "{}\n\n{}",
                     "        Invalid Output      ".black().on_bright_red(),
                     output


### PR DESCRIPTION
## Why

Currently, when a function reaches the `unreachable` instruction (panics), the output will look like this:
<img width="609" alt="Screen Shot 2022-06-23 at 12 40 10 PM" src="https://user-images.githubusercontent.com/39207554/175351630-e8388bba-67e6-4072-9cee-3b8b5e5461ab.png">

2x "Error:", no separation between logs and performance metrics and even no info at all opposed to what you would get by running a working function. Also, some logging info is lost, so it makes debugging harder.

## How

This is how the new error reporting looks like:
<img width="585" alt="Screen Shot 2022-06-23 at 11 15 19 AM" src="https://user-images.githubusercontent.com/39207554/175354237-86155252-0bfe-4d72-82ca-1e4694b917a4.png">

There is now the headers between the "results" and the "logs" that were previously only visible on successful functions.

There is now an "Error" header/block that displays the error reported by the Wasm engine. 

In the logs, there is now the panic message from the Wasm binary itself. This will help debugging, because it allows to see the panic message and it even shows on what line the panic occurred.

## Detail

Before, the structured output was not displayed, because the engine run function panicked because it was not able to serialize the output from the function. That was fixed by setting the output to null if the function did not output (as it happens when it panics).

 