### PR TITLE
Enable step debugging functions on x86 architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ contains binaries that can be run on your computer.
 
 To see the list of possible commands and arguments, run `function-runner --help`.
 
+When running this on x86 architectures (not Apple Silicon) and if you pass a Wasm file that includes debug symbols (that is, DWARF symbols), you can step debug your function with lldb by installing lldb and running:
+
+```
+lldb -- function-runner -f '../my-function-name.wasm' '../my-input.json'
+```
+
 ## Development
 
 Building requires a rust toolchain of at least `1.56.0` (older may work). `cargo install --path .` will build

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,12 +3,17 @@ use std::{
     path::PathBuf,
     time::{Duration, Instant},
 };
-use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime::{Config, Engine, Linker, Module, Store};
 
 use crate::function_run_result::FunctionRunResult;
 
 pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResult> {
-    let engine = Engine::default();
+    let engine = if cfg!(target_arch = "x86_64") {
+        // enabling this on non-x86 architectures currently causes an error (as of 2022-06-23)
+        Engine::new(Config::new().debug_info(true))?
+    } else {
+        Engine::default()
+    };
     let module = Module::from_file(&engine, &function_path)
         .map_err(|e| anyhow!("Couldn't load the Function {:?}: {}", &function_path, e))?;
 


### PR DESCRIPTION
`Config::new().debug_info(true)` is similar to passing the `-g` flag to `wasmtime`. It causes `wasmtime` to transform the DWARF symbols included in the Wasm file into DWARF symbols for the native code that is generated.

I tested on both x86 and Apple Silicon.