### PR TITLE
fix: memory usage in json

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,6 +7,8 @@ use wasmtime::{Engine, Linker, Module, Store};
 
 use crate::function_run_result::FunctionRunResult;
 
+const KB_PER_PAGE: u64 = 64;
+
 pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResult> {
     let engine = Engine::default();
     let module = Module::from_file(&engine, &function_path)
@@ -57,7 +59,8 @@ pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunRes
                 let memory = instance.get_memory(&mut store, name).unwrap();
                 memory.size(&store)
             })
-            .sum();
+            .sum::<u64>()
+            * KB_PER_PAGE;
 
         let module_result = instance
             .get_typed_func::<(), (), _>(&mut store, "_start")?

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -111,8 +111,8 @@ mod tests {
     use std::path::Path;
 
     // Arbitrary, used to verify that the runner works as expected.
-    const HELLO_WORLD_MEMORY_USAGE: u64 = 17;
-    const MODIFIED_HELLO_WORLD_MEMORY_USAGE: u64 = 42;
+    const HELLO_WORLD_MEMORY_USAGE: u64 = 17 * KB_PER_PAGE;
+    const MODIFIED_HELLO_WORLD_MEMORY_USAGE: u64 = 42 * KB_PER_PAGE;
 
     #[test]
     fn test_memory_usage_under_threshold() {

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -42,7 +42,7 @@ impl fmt::Display for FunctionRunResult {
         write!(f, "{}\n\n", title)?;
         writeln!(f, "Name: {}", self.name)?;
         writeln!(f, "Runtime: {:?}", self.runtime)?;
-        writeln!(f, "Memory Usage: {}KB", self.memory_usage * 64)?;
+        writeln!(f, "Memory Usage: {}KB", self.memory_usage)?;
         writeln!(f, "Size: {}KB\n", self.size / 1024)?;
 
         writeln!(


### PR DESCRIPTION
fixes #34 

Why? 
The memory usage reported in pages for the JSON output and in KB otherwise. 

How?
The conversion from pages to KB is now done in the engine instead of in the Display impl of the FunctionRunResult.