### PR TITLE
Add `--locked` to `cargo install` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ and add the `function-runner` command to your path.
 
 ### Commands
 
-- `cargo install --path .` : Build and install the `function-runner` command.
+- `cargo install --path . --locked` : Build and install the `function-runner` command.
 - `function-runner` : Execute a Function.


### PR DESCRIPTION
I tried installing function runner as per the README and ran into a compilation
error on "deterministic-wasi-ctx v0.1.5".

I was confused because function-runner locks that crate to 0.1.3 as of writing:
https://github.com/Shopify/function-runner/blob/13e86030659ecd8017912454014cdc226b293bbe/Cargo.lock#L448-L450

but then I learned that `cargo install` doesn't use the lockfile by default.

I figured including `--locked` in the README's install command would be best
for Rust novices like me. More experienced users can decide to leave it out.