### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.59.0
+          toolchain: stable
           default: true
 
       - name: Build ${{ matrix.os }}


### PR DESCRIPTION
It looks like `clap` has a minimum supported Rust version higher than 1.59. No idea why we're pegged to a specific version anyway given this is a binary and not a library.