### PR TITLE
Remove debug symbol transformation since it's unreliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,6 @@ contains binaries that can be run on your computer.
 
 To see the list of possible commands and arguments, run `function-runner --help`.
 
-### Debugging
-
-Wasm files with DWARF symbols can be debugged using `lldb` on x86 architectures (not Apple Silicon). To do this, install `lldb` and run:
-
-```
-lldb -- function-runner -f '../my-function-name.wasm' '../my-input.json'
-```
-
 ## Development
 
 Building requires a rust toolchain of at least `1.56.0` (older may work). `cargo install --path . --locked` will build

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
     time::{Duration, Instant},
 };
-use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime::{Engine, Linker, Module, Store};
 
 use crate::function_run_result::{
     FunctionOutput::{self, InvalidJsonOutput, JsonOutput},
@@ -12,12 +12,7 @@ use crate::function_run_result::{
 };
 
 pub fn run(function_path: PathBuf, input: Vec<u8>) -> Result<FunctionRunResult> {
-    let engine = if cfg!(target_arch = "x86_64") {
-        // enabling this on non-x86 architectures currently causes an error (as of wasmtime 0.37.0)
-        Engine::new(Config::new().debug_info(true))?
-    } else {
-        Engine::default()
-    };
+    let engine = Engine::default();
     let module = Module::from_file(&engine, &function_path)
         .map_err(|e| anyhow!("Couldn't load the Function {:?}: {}", &function_path, e))?;
 


### PR DESCRIPTION
Looks like enabling the debug symbol transformation is resulting in some modules not compiling due to an assertion failure in the Cranelift code in debug symbol transformation. I doubt this was being used anyway. But we can add it back behind a flag if we need to.