### PR TITLE
Another fix release

### DIFF
--- a/npm/function-runner/index.js
+++ b/npm/function-runner/index.js
@@ -133,6 +133,9 @@ function platarch() {
 		case "arm64":
 			arch = "arm";
 			break;
+		// A 32 bit arch likely needs that someone has 32bit Node installed on a
+		// 64 bit system, and wasmtime doesn't support 32bit anyway.
+		case "ia32":
 		case "x64":
 			arch = "x86_64";
 			break;

--- a/npm/function-runner/package-lock.json
+++ b/npm/function-runner/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "function-runner",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "function-runner",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/function-runner/package.json
+++ b/npm/function-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "function-runner",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
It _looks_ like this version (4.0.2) might be what's [released](https://www.npmjs.com/package/function-runner?activeTab=readme). We should merge it into `main` if that's the case.