### PR TITLE
chore: Remove `serde_derive` which is unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,6 @@ dependencies = [
  "predicates",
  "rust-embed",
  "serde",
- "serde_derive",
  "serde_json",
  "wasi-common",
  "wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ clap = { version = "4.1", features = ["derive"] }
 serde_json = "1.0"
 colored = "2.0"
 serde = "1.0"
-serde_derive = "1.0"
 rust-embed = "6.4.2"
 
 [dev-dependencies]


### PR DESCRIPTION
`cargo machete` marked `serde_derive` as unused

Similar to https://github.com/Shopify/javy/pull/292