### PR TITLE
Bumping rust version since dependabot requires 1.68+

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.67.0"
+channel = "1.69.0"
 components = [ "rustc", "rust-std", "cargo", "rust-docs", "rustfmt", "clippy" ]


### PR DESCRIPTION
Bumping rust version since dependabot requires 1.68+