### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "3.3.1"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "3.3.1"
+version = "3.4.0"
 edition = "2021"
 
 [profile.benchmark]


### PR DESCRIPTION
Bumped to version for a new release. Bumped to a minor, because of new backwards-compatible features.