### PR TITLE
upload release assets with 'gh release upload' during publish.yml action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,14 +83,9 @@ jobs:
           path: ${{ matrix.asset_name }}.gz
 
       - name: Upload assets to release
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.gz
-          asset_name: ${{ matrix.asset_name }}.gz
-          asset_content_type: application/gzip
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.asset_name }}.gz
 
       - name: Generate asset hash
         run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
@@ -102,11 +97,6 @@ jobs:
           path: ${{ matrix.asset_name }}.gz.sha256
 
       - name: Upload asset hash to release
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.gz.sha256
-          asset_name: ${{ matrix.asset_name }}.gz.sha256
-          asset_content_type: plain/text
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.asset_name }}.gz.sha256


### PR DESCRIPTION
Part of https://github.com/Shopify/script-service/issues/6337

`actions/upload-release-asset` is deprecated and uses a deprecated method, so we have to move away from it. I followed the approach taken by [Javy](https://github.com/bytecodealliance/javy/pull/214) to use the built-in `gh` cli to upload the assets to the release instead 