### PR TITLE
Release 3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 
 [profile.benchmark]


### PR DESCRIPTION
Release 3.5.0 so that `--profile` and `--export` becomes available to everyone.