### PR TITLE
Add workflow_dispatch with inputs.tag_name to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag name"
+        required: true
+        type: string
 
 jobs:
   compile:
@@ -15,31 +21,31 @@ jobs:
           - name: linux
             os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
             path: target/x86_64-unknown-linux-gnu/release/function-runner
-            asset_name: function-runner-x86_64-linux-${{ github.event.release.tag_name }}
+            asset_name: function-runner-x86_64-linux-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-unknown-linux-gnu
           - name: linux-arm64
             os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
             path: target/aarch64-unknown-linux-gnu/release/function-runner
-            asset_name: function-runner-arm-linux-${{ github.event.release.tag_name }}
+            asset_name: function-runner-arm-linux-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: aarch64-unknown-linux-gnu
           - name: macos
             os: macos-latest
             path: target/x86_64-apple-darwin/release/function-runner
-            asset_name: function-runner-x86_64-macos-${{ github.event.release.tag_name }}
+            asset_name: function-runner-x86_64-macos-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: shasum -a 256
             target: x86_64-apple-darwin
           - name: arm64-macos
             os: macos-latest
             path: target/aarch64-apple-darwin/release/function-runner
-            asset_name: function-runner-arm-macos-${{ github.event.release.tag_name }}
+            asset_name: function-runner-arm-macos-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: shasum -a 256
             target: aarch64-apple-darwin
           - name: windows
             os: windows-latest
             path: target\x86_64-pc-windows-msvc\release\function-runner.exe
-            asset_name: function-runner-x86_64-windows-${{ github.event.release.tag_name }}
+            asset_name: function-runner-x86_64-windows-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-pc-windows-msvc
 
@@ -47,13 +53,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install cross compiler
-        if:  ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Set up cross compiler env variables
-        if:  ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
@@ -85,7 +91,7 @@ jobs:
       - name: Upload assets to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.asset_name }}.gz
+        run: gh release upload ${{ inputs.tag_name || github.event.release.tag_name }} ${{ matrix.asset_name }}.gz
 
       - name: Generate asset hash
         run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
@@ -99,4 +105,4 @@ jobs:
       - name: Upload asset hash to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.asset_name }}.gz.sha256
+        run: gh release upload ${{ inputs.tag_name || github.event.release.tag_name }} ${{ matrix.asset_name }}.gz.sha256


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#configuring-a-workflow-to-run-manually

Not 100% sure how this works but trying to configure the button to manually run the publish workflow, as the Github UI release may have initially created the release as a draft.

<img width="1289" alt="Screenshot 2023-07-18 at 1 28 47 PM" src="https://github.com/Shopify/function-runner/assets/1707217/cc356932-0933-4224-8cef-7f352b863fc5">

I did try this on my own fork (now deleted).