### PR TITLE
Use an argument for JSON input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use function_runner::engine::{run, ProfileOpts};
 
 use is_terminal::IsTerminal;
@@ -87,10 +87,9 @@ fn main() -> Result<()> {
     } else if !std::io::stdin().is_terminal() {
         Box::new(BufReader::new(stdin()))
     } else {
-        Opts::command()
-            .print_help()
-            .expect("Printing help should not fail");
-        return Ok(());
+        return Err(anyhow!(
+            "You must provide input via the --input flag or piped via stdin."
+        ));
     };
 
     let mut buffer = Vec::new();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -82,22 +82,11 @@ mod tests {
     #[ignore = "This test hangs on CI but runs locally, is_terminal is likely returning false in CI"]
     fn run_function_no_input() -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = Command::cargo_bin("function-runner")?;
-        let output = cmd
-            .arg("--function")
-            .arg("benchmark/build/runtime_function.wasm")
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("Failed to spawn child process")
-            .wait_with_output()
-            .expect("Failed waiting for output");
 
-        let actual = String::from_utf8(output.stdout).unwrap();
-        let predicate = predicate::str::contains(
-            "Simple Function runner which takes JSON as a convenience\n\nUsage: function-runner",
-        )
-        .count(1);
-
-        assert!(predicate.eval(&actual));
+        cmd.args(["--function", "benchmark/build/runtime_function.wasm"]);
+        cmd.assert()
+            .failure()
+            .stderr("Error: You must provide input via the --input flag or piped via stdin.\n");
 
         Ok(())
     }


### PR DESCRIPTION
Related issue: https://github.com/Shopify/script-service/issues/6712

Because the `function-runner` is used by the Shopify CLI, if the function input is omitted, we want to simplify the error message so it makes sense when the CLI passes it through.

As described in the related issue, to improve this, `function-runner` now uses an `--input` argument to accept a JSON input file. If this is omitted _and_ there's no stdin, then a simplified error message is displayed instead of the `function-runner` help.

Note: this is technically a breaking change since we're switching usage from `function-runner [input]` to `function-runner --input`. This _could_ be a problem since the JS package auto-updates. However, through the CLI, this won't cause any issues since it uses stdin rather than a JSON file path.