### PR TITLE
Run publish action on publish and not create

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   release:
     types:
-      - created
+      - published
   workflow_dispatch:
     inputs:
       tag_name:


### PR DESCRIPTION
Closes https://github.com/Shopify/script-service/issues/7297

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
>Note: Workflows are not triggered for the created, edited, or deleted activity types for draft releases. When you create your release through the GitHub browser UI, your release may automatically be saved as a draft.

We ran into a problem where the workflow was not triggered when creating a release from a draft. This would have been solved by triggering the action on publish instead of create. 

[Javy](https://github.com/bytecodealliance/javy/blob/main/.github/workflows/build-assets.yml) does the same thing.