### PR TITLE
v4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 
 [profile.benchmark]


### PR DESCRIPTION
Bump version to prepare for a release. Uses `2023-12-09` version of QuickJS.