### PR TITLE
Disable reference types and threads

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -72,6 +72,8 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
     let engine = Engine::new(
         Config::new()
             .wasm_multi_memory(true)
+            .wasm_threads(false)
+            .wasm_reference_types(false)
             .consume_fuel(true)
             .epoch_interruption(true),
     )?;


### PR DESCRIPTION
Mirror changes in our server side configuration by disabling Wasm features that are not actively used (`reference_types` and `threads`)