### PR TITLE
v5.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 
 


### PR DESCRIPTION
The new release adds:
- proper memory accounting (https://github.com/Shopify/function-runner/commit/b7451e1fd36a01465ac4c91d77ab0a4b5eff35a4)
- support for `javy_quickjs_provider_v2`
