### PR TITLE
Print input prior to running function runner 

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -217,16 +217,19 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
     let name = function_path.file_name().unwrap().to_str().unwrap();
     let size = function_path.metadata()?.len() / 1024;
 
-    let function_run_result = FunctionRunResult::new(
-        name.to_string(),
+    let parsed_input =
+        String::from_utf8(input).map_err(|e| anyhow!("Couldn't parse input: {}", e))?;
+
+    let function_run_result = FunctionRunResult {
+        name: name.to_string(),
         size,
         memory_usage,
         instructions,
-        logs.to_string(),
-        String::from_utf8(input).unwrap(),
+        logs: logs.to_string(),
+        input: parsed_input,
         output,
-        profile_data,
-    );
+        profile: profile_data,
+    };
 
     Ok(function_run_result)
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -127,7 +127,7 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
     let module = Module::from_file(&engine, &function_path)
         .map_err(|e| anyhow!("Couldn't load the Function {:?}: {}", &function_path, e))?;
 
-    let input_stream = wasi_common::pipe::ReadPipe::new(Cursor::new(input));
+    let input_stream = wasi_common::pipe::ReadPipe::new(Cursor::new(input.clone()));
     let output_stream = wasi_common::pipe::WritePipe::new_in_memory();
     let error_stream = wasi_common::pipe::WritePipe::new(LogStream::default());
 
@@ -223,6 +223,7 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
         memory_usage,
         instructions,
         logs.to_string(),
+        String::from_utf8(input).unwrap(),
         output,
         profile_data,
     );

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -30,28 +30,6 @@ pub struct FunctionRunResult {
 }
 
 impl FunctionRunResult {
-    pub fn new(
-        name: String,
-        size: u64,
-        memory_usage: u64,
-        instructions: u64,
-        logs: String,
-        input: String,
-        output: FunctionOutput,
-        profile: Option<String>,
-    ) -> Self {
-        FunctionRunResult {
-            name,
-            size,
-            memory_usage,
-            instructions,
-            logs,
-            input,
-            output,
-            profile,
-        }
-    }
-
     pub fn to_json(&self) -> String {
         serde_json::to_string_pretty(&self).unwrap_or_else(|error| error.to_string())
     }

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -149,15 +149,19 @@ mod tests {
 
     #[test]
     fn test_js_output() {
+        let input_json = serde_json::json!({
+            "input_test": "input_value"
+        });
+        let input_vec = serde_json::to_vec(&input_json).unwrap();
+        let mock_input_string = String::from_utf8(input_vec).unwrap();
+
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
             size: 100,
             memory_usage: 1000,
             instructions: 1001,
             logs: "test".to_string(),
-            input: serde_json::json!({
-                "input_test": "input_value"
-            }),
+            input: mock_input_string.clone(),
             output: FunctionOutput::JsonOutput(serde_json::json!({
                 "test": "test"
             })),
@@ -165,22 +169,27 @@ mod tests {
         };
 
         let predicate = predicates::str::contains("Instructions: 1.001K")
-            .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
-            .and(predicates::str::contains("\"input_test\": \"input_value\""));
+            .and(predicates::str::contains(mock_input_string))
+            .and(predicates::str::contains("Linear Memory Usage: 1000KB"));
+
         assert!(predicate.eval(&function_run_result.to_string()));
     }
 
     #[test]
     fn test_js_output_1000() {
+        let input_json = serde_json::json!({
+            "input_test": "input_value"
+        });
+        let input_vec = serde_json::to_vec(&input_json).unwrap();
+        let mock_input_string = String::from_utf8(input_vec).unwrap();
+
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
             size: 100,
             memory_usage: 1000,
             instructions: 1000,
             logs: "test".to_string(),
-            input: serde_json::json!({
-                "input_test": "input_value"
-            }),
+            input: mock_input_string.clone(),
             output: FunctionOutput::JsonOutput(serde_json::json!({
                 "test": "test"
             })),
@@ -189,21 +198,25 @@ mod tests {
 
         let predicate = predicates::str::contains("Instructions: 1")
             .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
-            .and(predicates::str::contains("\"input_test\": \"input_value\""));
+            .and(predicates::str::contains(mock_input_string));
         assert!(predicate.eval(&function_run_result.to_string()));
     }
 
     #[test]
     fn test_instructions_less_than_1000() {
+        let input_json = serde_json::json!({
+            "input_test": "input_value"
+        });
+        let input_vec = serde_json::to_vec(&input_json).unwrap();
+        let mock_input_string = String::from_utf8(input_vec).unwrap();
+
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
             size: 100,
             memory_usage: 1000,
             instructions: 999,
             logs: "test".to_string(),
-            input: serde_json::json!({
-                "input_test": "input_value"
-            }),
+            input: mock_input_string.clone(),
             output: FunctionOutput::JsonOutput(serde_json::json!({
                 "test": "test"
             })),
@@ -212,7 +225,7 @@ mod tests {
 
         let predicate = predicates::str::contains("Instructions: 999")
             .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
-            .and(predicates::str::contains("\"input_test\": \"input_value\""));
+            .and(predicates::str::contains(mock_input_string));
         assert!(predicate.eval(&function_run_result.to_string()));
     }
 }

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -53,16 +53,6 @@ fn humanize_instructions(instructions: u64) -> String {
 
 impl fmt::Display for FunctionRunResult {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let title = "      Benchmark Results      "
-            .black()
-            .on_truecolor(150, 191, 72);
-
-        write!(formatter, "{title}\n\n")?;
-        writeln!(formatter, "Name: {}", self.name)?;
-        writeln!(formatter, "Linear Memory Usage: {}KB", self.memory_usage)?;
-        writeln!(formatter, "{}", humanize_instructions(self.instructions))?;
-        writeln!(formatter, "Size: {}KB\n", self.size)?;
-
         writeln!(
             formatter,
             "{}\n\n{}",
@@ -115,6 +105,16 @@ impl fmt::Display for FunctionRunResult {
             }
         }
 
+        let title = "     Benchmark Results      "
+            .black()
+            .on_truecolor(150, 191, 72);
+
+        write!(formatter, "\n\n{title}\n\n")?;
+        writeln!(formatter, "Name: {}", self.name)?;
+        writeln!(formatter, "Linear Memory Usage: {}KB", self.memory_usage)?;
+        writeln!(formatter, "{}", humanize_instructions(self.instructions))?;
+        writeln!(formatter, "Size: {}KB\n", self.size)?;
+
         Ok(())
     }
 }
@@ -127,11 +127,7 @@ mod tests {
 
     #[test]
     fn test_js_output() {
-        let input_json = serde_json::json!({
-            "input_test": "input_value"
-        });
-        let input_vec = serde_json::to_vec(&input_json).unwrap();
-        let mock_input_string = String::from_utf8(input_vec).unwrap();
+        let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
 
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
@@ -155,11 +151,7 @@ mod tests {
 
     #[test]
     fn test_js_output_1000() {
-        let input_json = serde_json::json!({
-            "input_test": "input_value"
-        });
-        let input_vec = serde_json::to_vec(&input_json).unwrap();
-        let mock_input_string = String::from_utf8(input_vec).unwrap();
+        let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
 
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
@@ -182,11 +174,7 @@ mod tests {
 
     #[test]
     fn test_instructions_less_than_1000() {
-        let input_json = serde_json::json!({
-            "input_test": "input_value"
-        });
-        let input_vec = serde_json::to_vec(&input_json).unwrap();
-        let mock_input_string = String::from_utf8(input_vec).unwrap();
+        let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
 
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -23,6 +23,7 @@ pub struct FunctionRunResult {
     pub memory_usage: u64,
     pub instructions: u64,
     pub logs: String,
+    pub input: String,
     pub output: FunctionOutput,
     #[serde(skip)]
     pub profile: Option<String>,
@@ -35,6 +36,7 @@ impl FunctionRunResult {
         memory_usage: u64,
         instructions: u64,
         logs: String,
+        input: String,
         output: FunctionOutput,
         profile: Option<String>,
     ) -> Self {
@@ -43,8 +45,9 @@ impl FunctionRunResult {
             size,
             memory_usage,
             instructions,
-            output,
             logs,
+            input,
+            output,
             profile,
         }
     }
@@ -81,6 +84,13 @@ impl fmt::Display for FunctionRunResult {
         writeln!(formatter, "Linear Memory Usage: {}KB", self.memory_usage)?;
         writeln!(formatter, "{}", humanize_instructions(self.instructions))?;
         writeln!(formatter, "Size: {}KB\n", self.size)?;
+
+        writeln!(
+            formatter,
+            "{}\n\n{}",
+            "            Input            ".black().on_bright_yellow(),
+            self.input
+        )?;
 
         writeln!(
             formatter,
@@ -145,6 +155,9 @@ mod tests {
             memory_usage: 1000,
             instructions: 1001,
             logs: "test".to_string(),
+            input: serde_json::json!({
+                "input_test": "input_value"
+            }),
             output: FunctionOutput::JsonOutput(serde_json::json!({
                 "test": "test"
             })),
@@ -152,7 +165,8 @@ mod tests {
         };
 
         let predicate = predicates::str::contains("Instructions: 1.001K")
-            .and(predicates::str::contains("Linear Memory Usage: 1000KB"));
+            .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
+            .and(predicates::str::contains("\"input_test\": \"input_value\""));
         assert!(predicate.eval(&function_run_result.to_string()));
     }
 
@@ -164,6 +178,9 @@ mod tests {
             memory_usage: 1000,
             instructions: 1000,
             logs: "test".to_string(),
+            input: serde_json::json!({
+                "input_test": "input_value"
+            }),
             output: FunctionOutput::JsonOutput(serde_json::json!({
                 "test": "test"
             })),
@@ -171,7 +188,8 @@ mod tests {
         };
 
         let predicate = predicates::str::contains("Instructions: 1")
-            .and(predicates::str::contains("Linear Memory Usage: 1000KB"));
+            .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
+            .and(predicates::str::contains("\"input_test\": \"input_value\""));
         assert!(predicate.eval(&function_run_result.to_string()));
     }
 
@@ -183,6 +201,9 @@ mod tests {
             memory_usage: 1000,
             instructions: 999,
             logs: "test".to_string(),
+            input: serde_json::json!({
+                "input_test": "input_value"
+            }),
             output: FunctionOutput::JsonOutput(serde_json::json!({
                 "test": "test"
             })),
@@ -190,7 +211,8 @@ mod tests {
         };
 
         let predicate = predicates::str::contains("Instructions: 999")
-            .and(predicates::str::contains("Linear Memory Usage: 1000KB"));
+            .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
+            .and(predicates::str::contains("\"input_test\": \"input_value\""));
         assert!(predicate.eval(&function_run_result.to_string()));
     }
 }


### PR DESCRIPTION
### Issue
https://github.com/Shopify/shopify-functions/issues/242

## What is this doing?

This PR adds input to `function-runner`'s output.  This will allow partners to confirm the input that was used to run the function. 

The update was adding input as a `String` type to the `FunctionRunResult`, and updated the `fmt` method so that it also displays the input along with the current output. 

Also, when we create the `FunctionRunResult` in engine - we initializes it with the input, which needs to be converted from a `Vec<u8>`. 

I am fairly unfamiliar with Rust, so please let me know if there is any improvements that can be made.


<img width="1080" alt="Screenshot 2024-07-15 at 3 03 46 PM" src="https://github.com/user-attachments/assets/933a2c06-af87-49b9-a26f-710ef10baf38">
