### PR TITLE
v5.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "5.1.3"
+version = "5.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "5.1.3"
+version = "5.1.4"
 edition = "2021"
 
 


### PR DESCRIPTION
Cutting a new version as per instructions [here](https://github.com/Shopify/function-runner?tab=readme-ov-file#releasing).

Updated version number to `v5.1.4` and ran `cargo build`

PR with changes introcuted: https://github.com/Shopify/function-runner/pull/312/files

Draft Release: https://github.com/Shopify/function-runner/releases/edit/untagged-cab601708c7ac618c6a2