### PR TITLE
Remove unnecessary action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,13 +69,6 @@ jobs:
       - name: Install target
         run: rustup target add ${{ matrix.target }}
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: stable
-          default: true
-
       - name: Build ${{ matrix.target }}
         run: cargo build --release --target ${{ matrix.target }} --package function-runner
 


### PR DESCRIPTION
The `actions-rs/toolchain` action is unmaintained and uses an unsupported version of Node. I don't believe it's actually necessary though. This PR removes it from our publish GH action.

Test run in my fork: https://github.com/andrewhassan/function-runner/actions/runs/10273827479