### PR TITLE
update FunctionRunResult display to output json

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,8 +6,7 @@ use wasmtime::{AsContextMut, Config, Engine, Linker, Module, ResourceLimiter, St
 
 use crate::{
     function_run_result::{
-        FunctionOutput::{self, InvalidJsonOutput, JsonOutput},
-        FunctionRunResult, InvalidOutput,
+        FunctionInput::{self, JsonInput}, FunctionOutput::{self, InvalidJsonOutput, JsonOutput}, FunctionRunResult, InvalidOutput
     },
     logs::LogStream,
 };
@@ -220,13 +219,15 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
     let parsed_input =
         String::from_utf8(input).map_err(|e| anyhow!("Couldn't parse input: {}", e))?;
 
+    let function_run_input: FunctionInput = JsonInput(serde_json::from_str(&parsed_input)?);
+
     let function_run_result = FunctionRunResult {
         name: name.to_string(),
         size,
         memory_usage,
         instructions,
         logs: logs.to_string(),
-        input: parsed_input,
+        input: function_run_input,
         output,
         profile: profile_data,
     };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,9 @@ use wasmtime::{AsContextMut, Config, Engine, Linker, Module, ResourceLimiter, St
 
 use crate::{
     function_run_result::{
-        FunctionInput::{self, JsonInput}, FunctionOutput::{self, InvalidJsonOutput, JsonOutput}, FunctionRunResult, InvalidOutput
+        FunctionInput::{self, JsonInput},
+        FunctionOutput::{self, InvalidJsonOutput, JsonOutput},
+        FunctionRunResult, InvalidOutput,
     },
     logs::LogStream,
 };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,6 @@ use wasmtime::{AsContextMut, Config, Engine, Linker, Module, ResourceLimiter, St
 
 use crate::{
     function_run_result::{
-        FunctionInput::{self, JsonInput},
         FunctionOutput::{self, InvalidJsonOutput, JsonOutput},
         FunctionRunResult, InvalidOutput,
     },
@@ -221,7 +220,7 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
     let parsed_input =
         String::from_utf8(input).map_err(|e| anyhow!("Couldn't parse input: {}", e))?;
 
-    let function_run_input: FunctionInput = JsonInput(serde_json::from_str(&parsed_input)?);
+    let function_run_input = serde_json::from_str(&parsed_input)?;
 
     let function_run_result = FunctionRunResult {
         name: name.to_string(),

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -58,7 +58,8 @@ impl fmt::Display for FunctionRunResult {
             formatter,
             "{}\n\n{}",
             "            Input            ".black().on_bright_yellow(),
-            serde_json::to_string_pretty(&self.input).unwrap_or_else(|error| error.to_string())
+            serde_json::to_string_pretty(&self.input)
+                .expect("Input should be serializable to a string")
         )?;
 
         writeln!(
@@ -86,7 +87,7 @@ impl fmt::Display for FunctionRunResult {
                     "{}\n\n{}",
                     "           Output           ".black().on_bright_green(),
                     serde_json::to_string_pretty(&json_output)
-                        .unwrap_or_else(|error| error.to_string())
+                        .expect("Output should be serializable to a string")
                 )?;
             }
             FunctionOutput::InvalidJsonOutput(invalid_output) => {

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -18,19 +18,13 @@ pub enum FunctionOutput {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum FunctionInput {
-    JsonInput(serde_json::Value),
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FunctionRunResult {
     pub name: String,
     pub size: u64,
     pub memory_usage: u64,
     pub instructions: u64,
     pub logs: String,
-    pub input: FunctionInput,
+    pub input: serde_json::Value,
     pub output: FunctionOutput,
     #[serde(skip)]
     pub profile: Option<String>,
@@ -136,8 +130,7 @@ mod tests {
     #[test]
     fn test_js_output() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
-        let mock_function_input =
-            FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let mock_function_input = serde_json::from_str(&mock_input_string)?;
         let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
@@ -164,8 +157,7 @@ mod tests {
     #[test]
     fn test_js_output_1000() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
-        let mock_function_input =
-            FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let mock_function_input = serde_json::from_str(&mock_input_string)?;
         let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
@@ -191,8 +183,7 @@ mod tests {
     #[test]
     fn test_instructions_less_than_1000() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
-        let mock_function_input =
-            FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let mock_function_input = serde_json::from_str(&mock_input_string)?;
         let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -20,7 +20,7 @@ pub enum FunctionOutput {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum FunctionInput {
-    JsonInput(serde_json::Value)
+    JsonInput(serde_json::Value),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -60,13 +60,11 @@ fn humanize_instructions(instructions: u64) -> String {
 
 impl fmt::Display for FunctionRunResult {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        
         writeln!(
             formatter,
             "{}\n\n{}",
             "            Input            ".black().on_bright_yellow(),
-            serde_json::to_string_pretty(&self.input)
-                .unwrap_or_else(|error| error.to_string())
+            serde_json::to_string_pretty(&self.input).unwrap_or_else(|error| error.to_string())
         )?;
 
         writeln!(
@@ -130,15 +128,16 @@ impl fmt::Display for FunctionRunResult {
 
 #[cfg(test)]
 mod tests {
-    use predicates::prelude::*;
     use anyhow::Result;
+    use predicates::prelude::*;
 
     use super::*;
 
     #[test]
     fn test_js_output() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
-        let mock_function_input = FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let mock_function_input =
+            FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
         let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
@@ -165,7 +164,8 @@ mod tests {
     #[test]
     fn test_js_output_1000() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
-        let mock_function_input = FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let mock_function_input =
+            FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
         let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
@@ -191,7 +191,8 @@ mod tests {
     #[test]
     fn test_instructions_less_than_1000() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
-        let mock_function_input = FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let mock_function_input =
+            FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
         let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -139,6 +139,7 @@ mod tests {
     fn test_js_output() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
         let mock_function_input = FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
@@ -154,8 +155,8 @@ mod tests {
         };
 
         let predicate = predicates::str::contains("Instructions: 1.001K")
-            .and(predicates::str::contains(mock_input_string))
-            .and(predicates::str::contains("Linear Memory Usage: 1000KB"));
+            .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
+            .and(predicates::str::contains(expected_input_display));
 
         assert!(predicate.eval(&function_run_result.to_string()));
         Ok(())
@@ -165,6 +166,7 @@ mod tests {
     fn test_js_output_1000() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
         let mock_function_input = FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
@@ -181,7 +183,7 @@ mod tests {
 
         let predicate = predicates::str::contains("Instructions: 1")
             .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
-            .and(predicates::str::contains(mock_input_string));
+            .and(predicates::str::contains(expected_input_display));
         assert!(predicate.eval(&function_run_result.to_string()));
         Ok(())
     }
@@ -190,6 +192,7 @@ mod tests {
     fn test_instructions_less_than_1000() -> Result<()> {
         let mock_input_string = "{\"input_test\": \"input_value\"}".to_string();
         let mock_function_input = FunctionInput::JsonInput(serde_json::from_str(&mock_input_string)?);
+        let expected_input_display = serde_json::to_string_pretty(&mock_function_input)?;
 
         let function_run_result = FunctionRunResult {
             name: "test".to_string(),
@@ -206,7 +209,7 @@ mod tests {
 
         let predicate = predicates::str::contains("Instructions: 999")
             .and(predicates::str::contains("Linear Memory Usage: 1000KB"))
-            .and(predicates::str::contains(mock_input_string));
+            .and(predicates::str::contains(expected_input_display));
         assert!(predicate.eval(&function_run_result.to_string()));
         Ok(())
     }


### PR DESCRIPTION
Doing 2 things here:

1. Using [untagged](https://serde.rs/enum-representations.html#untagged) as the json output
Previously, when outputting the result of running function-runner, the output would contain the actual function output in an additional "layer" of the hash, with the tag as the key. i.e.

```  
  "output": {
    "JsonOutput": {
      "discountApplicationStrategy": "FIRST",
      "discounts": [
```

This causes issues on the CLI side when attempting to parse the response, since we're encountering an unknown / arbitrary extra level of nesting.

This PR changes to output to remove that extra level, resulting in something like:
```
  "output": {
    "discountApplicationStrategy": "FIRST",
    "discounts": [
```

2. Updating `input` data to be JSON.
We're already storing the `output` as JSON, and we already parse the `input` to JSON to run it, so we should store it as JSON as well.