### PR TITLE
release v6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "5.1.4"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "5.1.4"
+version = "6.0.0"
 edition = "2021"
 
 


### PR DESCRIPTION
new release to include the latest changes, in particular the change of output format from https://github.com/Shopify/function-runner/pull/329

following the [instructions from the readme](https://github.com/Shopify/function-runner?tab=readme-ov-file#releasing) 