### PR TITLE
v6.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 
 


### PR DESCRIPTION
bumping version to v6.2.0

Went with a minor change as per [semver](https://semver.org/) docs: `MINOR version when you add functionality in a backward compatible manner`