### PR TITLE
Minify input JSON

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,9 @@ fn main() -> Result<()> {
         Codec::Json => {
             let json = serde_json::from_slice::<serde_json::Value>(&buffer)
                 .map_err(|e| anyhow!("Invalid input JSON: {}", e))?;
-            (Some(json), buffer)
+            let minified_buffer =
+                serde_json::to_vec(&json).map_err(|e| anyhow!("Couldn't serialize JSON: {}", e))?;
+            (Some(json), minified_buffer)
         }
         Codec::Raw => (None, buffer),
         Codec::JsonToMessagepack => {


### PR DESCRIPTION
To be more aligned with how functions are run in production, the Function Runner should minify JSON input before passing it into the function. That way, the performance profile of JSON decoding the input is much closer to production. 