### PR TITLE
Bump version to 6.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "6.2.0"
+version = "6.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "6.2.0"
+version = "6.2.1"
 edition = "2021"
 
 


### PR DESCRIPTION
Bump the version to 6.2.1. Changes: https://github.com/Shopify/function-runner/compare/v6.2.0...ah.v6.2.1?expand=1