### PR TITLE
v6.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "6.2.1"
+version = "6.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "6.2.1"
+version = "6.3.0"
 edition = "2021"
 
 


### PR DESCRIPTION
Preparing for a release that includes the new Javy QuickJS provider. This provider update will support newer Javy modules that are generated with calls to `invoke` with null function names.