### PR TITLE
Add missing rerun in build.rs file

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
     println!("cargo:rerun-if-changed=providers/javy_quickjs_provider_v1.wasm");
     println!("cargo:rerun-if-changed=providers/javy_quickjs_provider_v2.wasm");
+    println!("cargo:rerun-if-changed=providers/javy_quickjs_provider_v3.wasm");
 }


### PR DESCRIPTION
I noticed a `cargo:rerun-if-changed` was missing for the v3 QuickJS provider in the build file.