### PR TITLE
v8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2021"
 
 


### PR DESCRIPTION
Went with a major version because we removed support for the `--codec` flag and slightly changed the format of the `--json` output