### PR TITLE
Bump ubuntu version to fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,13 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
+            os: ubuntu-22.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
             path: target/x86_64-unknown-linux-gnu/release/function-runner
             asset_name: function-runner-x86_64-linux-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-unknown-linux-gnu
           - name: linux-arm64
-            os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
+            os: ubuntu-22.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
             path: target/aarch64-unknown-linux-gnu/release/function-runner
             asset_name: function-runner-arm-linux-${{ inputs.tag_name || github.event.release.tag_name }}
             shasum_cmd: sha256sum


### PR DESCRIPTION
ubuntu 20.04 is no longer supported in GH actions