### PR TITLE
v8.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "function-runner"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "function-runner"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 
 


### PR DESCRIPTION
The release for 8.0.0 does not include a windows build because that failed. This should fix that issue thanks to #470 