### PR TITLE
Add module caching

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -238,13 +238,14 @@ pub fn run(params: FunctionRunParams) -> Result<FunctionRunResult> {
 /// 2. It keeps the door open for different configurations in the future without breaking changes
 /// 3. It makes it easier to find all places where we create an Engine
 pub fn new_engine() -> Result<Engine> {
-    Engine::new(
-        Config::new()
-            .wasm_multi_memory(true)
-            .wasm_threads(false)
-            .consume_fuel(true)
-            .epoch_interruption(true),
-    )
+    let mut config = Config::new();
+    config
+        .wasm_multi_memory(true)
+        .wasm_threads(false)
+        .consume_fuel(true)
+        .epoch_interruption(true);
+    config.cache_config_load_default()?;
+    Engine::new(&config)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use disk-based caching of compiled modules

By default it stores the files in the following locations

`BytecodeAlliance.wasmtime`

    /// |Platform | Value                                                                 | Example                                             |
    /// | ------- | --------------------------------------------------------------------- | --------------------------------------------------- |
    /// | Linux   | `$XDG_CACHE_HOME`/`_project_path_` or `$HOME`/.cache/`_project_path_` | /home/alice/.cache/barapp                           |
    /// | macOS   | `$HOME`/Library/Caches/`_project_path_`                               | /Users/Alice/Library/Caches/com.Foo-Corp.Bar-App    |
    /// | Windows | `{FOLDERID_LocalAppData}`\\`_project_path_`\\cache                    | C:\Users\Alice\AppData\Local\Foo Corp\Bar App\cache |
    
    
By default compiled modules are cached for 1 hour.