### PR TITLE
Remove unused use statement causing warning

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,7 +8,6 @@ mod tests {
     use predicates::prelude::*;
     use predicates::{prelude::predicate, str::contains};
     use serde_json::json;
-    use std::io::Write;
     use std::{
         fs::File,
         process::{Command, Stdio},


### PR DESCRIPTION
I noticed the main branch has a warning because this `use` statement isn't necessary.