### PR TITLE
Preserve JSON input object order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,6 +2588,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ wasmtime-wasi = "=39.0.1"
 deterministic-wasi-ctx = "=3.0.4"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 colored = "3.1"
 serde = "1.0"
 rust-embed = "8.11.0"

--- a/src/container.rs
+++ b/src/container.rs
@@ -136,3 +136,21 @@ impl BytesContainer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_input_preserves_object_key_order_in_raw_bytes() {
+        let raw = br#"{"msg":{"sq-XK":"5.00 EUR Zbritje","en":"5.00 EUR Discount"}}"#.to_vec();
+
+        let input = BytesContainer::new(BytesContainerType::Input, Codec::Json, raw.clone())
+            .expect("valid JSON input");
+
+        assert_eq!(
+            String::from_utf8(input.raw).unwrap(),
+            String::from_utf8(raw).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
## 📚 Stack (bottom → top)
1. #595 Add batch mode for processing multiple inputs via JSONL
2. #590 Preserve JSON input object order
3. #591 Refine batch failure handling
4. #592 Reuse the compiled provider across runs
5. #593 Compute humanized bytes lazily
6. #594 Add minimal batch output with `--batch-full-output` opt-in

> Stacked PRs — review bottom-up.

---

## Why

`function-runner` parses each JSON input into `serde_json::Value` and
reserializes it to bytes before handing it to the Wasm module. With
`serde_json`'s default map, object keys are reordered lexicographically. JS
functions that rely on `Object.keys()` ordering can then behave differently under
replay than in production, breaking parity.

## What

- Enable `serde_json`'s `preserve_order` feature so input object key order is
  retained end-to-end through the runner.
- Add a regression test covering nested, metafield-like message objects to lock
  in the ordering guarantee.

This brings `function-rerunner` inputs closer to real production bytes.

## Testing

- `cargo test json_input_preserves_object_key_order_in_raw_bytes`
- `cargo build --release`
- `cargo test`
- Re-ran the 17 discount localized-message mismatch rows with the fixed release
  runner → full semantic matches.

