### PR TITLE
Refine batch failure handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -227,7 +227,7 @@ fn run_batch_mode(
         ));
     };
 
-    // Pre-calculate scale factor (constant across all inputs in batch)
+    // Load schema/query once; scale factor is computed per input.
     let schema_string = opts.read_schema_to_string().transpose()?;
     let query_string = opts.read_query_to_string().transpose()?;
 
@@ -235,8 +235,9 @@ fn run_batch_mode(
     let profile_opts = None;
 
     let mut line_num = 0;
+    let mut processed_count = 0;
     let mut success_count = 0;
-    let mut error_count = 0;
+    let mut failed_count = 0;
 
     for line_result in input_reader.lines() {
         line_num += 1;
@@ -244,7 +245,7 @@ fn run_batch_mode(
         let line = match line_result {
             Ok(l) => l,
             Err(e) => {
-                error_count += 1;
+                failed_count += 1;
                 if opts.batch_continue_on_error {
                     eprintln!("Error reading line {}: {}", line_num, e);
                     println!(
@@ -263,11 +264,13 @@ fn run_batch_mode(
             continue;
         }
 
+        processed_count += 1;
+
         // Parse input
         let input = match BytesContainer::new(BytesContainerType::Input, codec, line.into_bytes()) {
             Ok(i) => i,
             Err(e) => {
-                error_count += 1;
+                failed_count += 1;
                 if opts.batch_continue_on_error {
                     eprintln!("Error parsing line {}: {}", line_num, e);
                     println!(r#"{{"success":false,"error":"Invalid JSON input: {}"}}"#, e);
@@ -292,7 +295,7 @@ fn run_batch_mode(
                 ) {
                     Ok(sf) => sf,
                     Err(e) => {
-                        error_count += 1;
+                        failed_count += 1;
                         if opts.batch_continue_on_error {
                             eprintln!("Error analyzing schema for line {}: {}", line_num, e);
                             println!(
@@ -323,14 +326,27 @@ fn run_batch_mode(
         // Output result immediately (streaming JSONL - compact format for line-by-line parsing)
         match result {
             Ok(function_result) => {
-                success_count += 1;
+                let function_succeeded = function_result.success;
+                if function_succeeded {
+                    success_count += 1;
+                } else {
+                    failed_count += 1;
+                }
+
                 // Use compact JSON (not pretty-printed) for JSONL format
                 let compact_json = serde_json::to_string(&function_result)
                     .unwrap_or_else(|error| error.to_string());
                 println!("{}", compact_json);
+
+                if !function_succeeded && !opts.batch_continue_on_error {
+                    anyhow::bail!(
+                        "Function execution failed on line {}. Review the logs for more information.",
+                        line_num
+                    );
+                }
             }
             Err(e) => {
-                error_count += 1;
+                failed_count += 1;
                 if opts.batch_continue_on_error {
                     eprintln!("Error executing line {}: {}", line_num, e);
                     println!(r#"{{"success":false,"error":"Execution failed: {}"}}"#, e);
@@ -343,8 +359,8 @@ fn run_batch_mode(
 
     // Log summary to stderr (so it doesn't interfere with JSONL output on stdout)
     eprintln!(
-        "Batch complete: {} inputs processed, {} successful, {} errors",
-        line_num, success_count, error_count
+        "Batch complete: {} inputs processed, {} successful, {} failed",
+        processed_count, success_count, failed_count
     );
 
     Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -65,6 +65,69 @@ mod tests {
     }
 
     #[test]
+    fn batch_continue_on_error_processes_all_and_counts_function_failures() -> Result<()> {
+        let mut cmd = Command::new(cargo_bin!());
+        let input_file = temp_batch_input("{\"code\":0}\n{\"code\":1}\n{\"code\":0}\n")?;
+
+        cmd.args(["--function", "tests/fixtures/build/exit_code.wasm"])
+            .arg("--batch")
+            .arg("--batch-continue-on-error")
+            .arg("--input")
+            .arg(input_file.as_os_str());
+
+        let output = cmd.output()?;
+
+        assert!(output.status.success());
+
+        let stdout = String::from_utf8(output.stdout)?;
+        let results = stdout
+            .lines()
+            .map(serde_json::from_str::<serde_json::Value>)
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0]["success"], true);
+        assert_eq!(results[1]["success"], false);
+        assert_eq!(results[2]["success"], true);
+
+        assert_eq!(
+            String::from_utf8(output.stderr)?,
+            "Batch complete: 3 inputs processed, 2 successful, 1 failed\n"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn batch_stops_on_function_failure_by_default() -> Result<()> {
+        let mut cmd = Command::new(cargo_bin!());
+        let input_file = temp_batch_input("{\"code\":0}\n{\"code\":1}\n{\"code\":0}\n")?;
+
+        cmd.args(["--function", "tests/fixtures/build/exit_code.wasm"])
+            .arg("--batch")
+            .arg("--input")
+            .arg(input_file.as_os_str());
+
+        let output = cmd.output()?;
+
+        assert!(!output.status.success());
+
+        let stdout = String::from_utf8(output.stdout)?;
+        let results = stdout
+            .lines()
+            .map(serde_json::from_str::<serde_json::Value>)
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["success"], true);
+        assert_eq!(results[1]["success"], false);
+
+        assert!(String::from_utf8(output.stderr)?.contains(
+            "Function execution failed on line 2. Review the logs for more information."
+        ));
+
+        Ok(())
+    }
+
+    #[test]
     fn run_no_opts() -> Result<()> {
         let mut cmd = Command::new(cargo_bin!());
         let output = cmd
@@ -261,6 +324,13 @@ mod tests {
     fn temp_input(json: serde_json::Value) -> Result<assert_fs::NamedTempFile> {
         let file = assert_fs::NamedTempFile::new("input.json")?;
         file.write_str(json.to_string().as_str())?;
+
+        Ok(file)
+    }
+
+    fn temp_batch_input(jsonl: &str) -> Result<assert_fs::NamedTempFile> {
+        let file = assert_fs::NamedTempFile::new("input.jsonl")?;
+        file.write_str(jsonl)?;
 
         Ok(file)
     }


### PR DESCRIPTION
## 📚 Stack (bottom → top)
1. #595 Add batch mode for processing multiple inputs via JSONL
2. #590 Preserve JSON input object order
3. #591 Refine batch failure handling
4. #592 Reuse the compiled provider across runs
5. #593 Compute humanized bytes lazily
6. #594 Add minimal batch output with `--batch-full-output` opt-in

> Stacked PRs — review bottom-up.

---

## Why

The initial batch mode counted every run that returned `Ok` as a success — even
when the function itself returned `success: false` — so batch summaries were
wrong.

## What

- Keep `--batch-continue-on-error` (opt-in; batch **stops on the first error by
  default**). No new flag.
- Count real successes/failures from `FunctionRunResult.success`; track
  processed / successful / failed.
- Treat a function-level failure (`success: false`) like an error: it stops the
  batch by default, and is recorded-but-skipped under `--batch-continue-on-error`.
- The stderr summary reports processed, successful, and failed counts.
- Switch integration tests to `assert_cmd::cargo::cargo_bin!` (the
  non-deprecated API) in place of `Command::cargo_bin`.

## Testing

- `cargo test batch_`
- `cargo test`

