### PR TITLE
Add minimal batch output with --batch-full-output opt-in

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use function_runner::{BytesContainer, BytesContainerType, Codec};
+use serde::Serialize;
 use wasmtime::Module;
 
 use std::{
@@ -69,6 +70,10 @@ struct Opts {
     /// In batch mode, continue processing on individual input errors (default: false)
     #[clap(long)]
     batch_continue_on_error: bool,
+
+    /// In batch mode, emit the full FunctionRunResult for each input (default: minimal output)
+    #[clap(long)]
+    batch_full_output: bool,
 }
 
 impl Opts {
@@ -213,6 +218,29 @@ fn run_single_mode(
     }
 }
 
+#[derive(Serialize)]
+struct MinimalBatchRunResult<'a> {
+    success: bool,
+    instructions: u64,
+    memory_usage: u64,
+    logs: &'a str,
+    output: &'a BytesContainer,
+}
+
+impl<'a> From<&'a function_runner::function_run_result::FunctionRunResult>
+    for MinimalBatchRunResult<'a>
+{
+    fn from(result: &'a function_runner::function_run_result::FunctionRunResult) -> Self {
+        Self {
+            success: result.success,
+            instructions: result.instructions,
+            memory_usage: result.memory_usage,
+            logs: &result.logs,
+            output: &result.output,
+        }
+    }
+}
+
 fn run_batch_mode(
     opts: &Opts,
     engine: &wasmtime::Engine,
@@ -338,8 +366,12 @@ fn run_batch_mode(
                 }
 
                 // Use compact JSON (not pretty-printed) for JSONL format
-                let compact_json = serde_json::to_string(&function_result)
-                    .unwrap_or_else(|error| error.to_string());
+                let compact_json = if opts.batch_full_output {
+                    serde_json::to_string(&function_result)
+                } else {
+                    serde_json::to_string(&MinimalBatchRunResult::from(&function_result))
+                }
+                .unwrap_or_else(|error| error.to_string());
                 println!("{}", compact_json);
 
                 if !function_succeeded && !opts.batch_continue_on_error {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -88,11 +88,46 @@ mod tests {
         assert_eq!(results[0]["success"], true);
         assert_eq!(results[1]["success"], false);
         assert_eq!(results[2]["success"], true);
+        assert_eq!(results[0]["output"], json!({"exit": 0}));
+        assert!(results[0].get("instructions").is_some());
+        assert!(results[0].get("input").is_none());
+        assert!(results[0].get("name").is_none());
+        assert!(results[0].get("size").is_none());
 
         assert_eq!(
             String::from_utf8(output.stderr)?,
             "Batch complete: 3 inputs processed, 2 successful, 1 failed\n"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn batch_full_output_includes_input_and_function_metadata() -> Result<()> {
+        let mut cmd = Command::new(cargo_bin!());
+        let input_file = temp_batch_input("{\"code\":0}\n")?;
+
+        cmd.args(["--function", "tests/fixtures/build/exit_code.wasm"])
+            .arg("--batch")
+            .arg("--batch-full-output")
+            .arg("--input")
+            .arg(input_file.as_os_str());
+
+        let output = cmd.output()?;
+
+        assert!(output.status.success());
+
+        let stdout = String::from_utf8(output.stdout)?;
+        let results = stdout
+            .lines()
+            .map(serde_json::from_str::<serde_json::Value>)
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["success"], true);
+        assert_eq!(results[0]["input"], json!({"code": 0}));
+        assert_eq!(results[0]["output"], json!({"exit": 0}));
+        assert_eq!(results[0]["name"], "exit_code.wasm");
+        assert!(results[0].get("size").is_some());
 
         Ok(())
     }


### PR DESCRIPTION
## 📚 Stack (bottom → top)
1. #595 Add batch mode for processing multiple inputs via JSONL
2. #590 Preserve JSON input object order
3. #591 Refine batch failure handling
4. #592 Reuse the compiled provider across runs
5. #593 Compute humanized bytes lazily
6. #594 Add minimal batch output with `--batch-full-output` opt-in

> Stacked PRs — review bottom-up.

---

## Why

Batch mode emitted the full `FunctionRunResult` per input — including the echoed
input, function name, and size. Parity replay only needs the run outcome, and
the extra fields bloat the JSONL output for large runs.

## What

- Default batch output is now a **minimal** record per line:
  `success`, `instructions`, `memory_usage`, `logs`, `output`.
- Add `--batch-full-output` to opt back into the complete `FunctionRunResult`
  per line.
- Extend integration coverage for both the minimal default and the
  full-output flag.

Single-run output is unaffected.

## Testing

- `cargo test batch_`
- `cargo test`

