### PR TITLE
Add preserve_order to normalize fuel_usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,6 +2588,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ wasmtime-wasi = "=39.0.1"
 deterministic-wasi-ctx = "=3.0.4"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 colored = "3.1"
 serde = "1.0"
 rust-embed = "8.11.0"


### PR DESCRIPTION
I'm noticing some mismatches between the fuel consumption function-runner reports and the amount of fuel consumed in production for msgpack inputs and I think it's because we don't preserve the input order in function-runner. Preserving the input order seems to clear up most fuel consumed mismatches.