### PR TITLE
Escape slashes when formatting JSON

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -1,6 +1,38 @@
+use std::io;
+
 use crate::Codec;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
+
+#[derive(Default)]
+struct ShopifyJsonFormatter;
+
+impl serde_json::ser::Formatter for ShopifyJsonFormatter {
+    fn write_string_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        let mut start = 0;
+        for (index, byte) in fragment.bytes().enumerate() {
+            if byte == b'/' {
+                writer.write_all(&fragment.as_bytes()[start..index])?;
+                writer.write_all(br"\/")?;
+                start = index + 1;
+            }
+        }
+        writer.write_all(&fragment.as_bytes()[start..])
+    }
+}
+
+fn to_shopify_json_vec(value: &serde_json::Value) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let formatter = ShopifyJsonFormatter;
+    let mut serializer = serde_json::Serializer::with_formatter(&mut bytes, formatter);
+    value
+        .serialize(&mut serializer)
+        .map_err(|e| anyhow!("Couldn't serialize JSON: {}", e))?;
+    Ok(bytes)
+}
 
 #[derive(Debug, Clone, Default)]
 pub enum BytesContainerType {
@@ -64,8 +96,7 @@ impl BytesContainer {
                 BytesContainerType::Input => {
                     let json = serde_json::from_slice::<serde_json::Value>(&raw)
                         .map_err(|e| anyhow!("Invalid input JSON: {}", e))?;
-                    let minified_buffer = serde_json::to_vec(&json)
-                        .map_err(|e| anyhow!("Couldn't serialize JSON: {}", e))?;
+                    let minified_buffer = to_shopify_json_vec(&json)?;
 
                     Ok(Self {
                         codec,
@@ -134,5 +165,38 @@ impl BytesContainer {
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_input_escapes_solidus_like_shopify_json() -> Result<()> {
+        let input = br#"{"id":"gid://shopify/Product/1"}"#.to_vec();
+
+        let container = BytesContainer::new(BytesContainerType::Input, Codec::Json, input)?;
+
+        assert_eq!(
+            String::from_utf8(container.raw).unwrap(),
+            r#"{"id":"gid:\/\/shopify\/Product\/1"}"#
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn json_input_preserves_object_order() -> Result<()> {
+        let input = br#"{"b":1,"a":2}"#.to_vec();
+
+        let container = BytesContainer::new(BytesContainerType::Input, Codec::Json, input)?;
+
+        assert_eq!(
+            String::from_utf8(container.raw).unwrap(),
+            r#"{"b":1,"a":2}"#
+        );
+
+        Ok(())
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -13,11 +13,24 @@ impl serde_json::ser::Formatter for ShopifyJsonFormatter {
         W: ?Sized + io::Write,
     {
         let mut start = 0;
-        for (index, byte) in fragment.bytes().enumerate() {
-            if byte == b'/' {
-                writer.write_all(&fragment.as_bytes()[start..index])?;
-                writer.write_all(br"\/")?;
-                start = index + 1;
+        for (index, character) in fragment.char_indices() {
+            match character {
+                '/' => {
+                    writer.write_all(&fragment.as_bytes()[start..index])?;
+                    writer.write_all(br"\/")?;
+                    start = index + character.len_utf8();
+                }
+                '\u{2028}' => {
+                    writer.write_all(&fragment.as_bytes()[start..index])?;
+                    writer.write_all(br"\u2028")?;
+                    start = index + character.len_utf8();
+                }
+                '\u{2029}' => {
+                    writer.write_all(&fragment.as_bytes()[start..index])?;
+                    writer.write_all(br"\u2029")?;
+                    start = index + character.len_utf8();
+                }
+                _ => {}
             }
         }
         writer.write_all(&fragment.as_bytes()[start..])
@@ -181,6 +194,22 @@ mod tests {
         assert_eq!(
             String::from_utf8(container.raw).unwrap(),
             r#"{"id":"gid:\/\/shopify\/Product\/1"}"#
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn json_input_escapes_line_and_paragraph_separators_like_shopify_json() -> Result<()> {
+        let input = "{\"line\":\"before\u{2028}after\",\"paragraph\":\"before\u{2029}after\"}"
+            .as_bytes()
+            .to_vec();
+
+        let container = BytesContainer::new(BytesContainerType::Input, Codec::Json, input)?;
+
+        assert_eq!(
+            String::from_utf8(container.raw).unwrap(),
+            r#"{"line":"before\u2028after","paragraph":"before\u2029after"}"#
         );
 
         Ok(())


### PR DESCRIPTION
I noticed function-runner does not escape slashes in formatted JSON input but we do escape slashes in JSON input in production so function-runner reports different fuel consumption.

We also need to do the reverse for invisible control characters for newlines (u2028) and paragraphs (u2029).