### PR TITLE
Create CODEOWNERS file so we get notified about PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repository
+* @shopify/functions-dependabot-reviewers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    reviewers:
-      - "@Shopify/functions-dependabot-reviewers"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
@@ -27,7 +25,5 @@ updates:
           - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
-    reviewers:
-      - "@Shopify/functions-dependabot-reviewers"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I don't think the reviewer section of the Dependabot file was working correctly because we were not being notified about Dependabot PRs. But also we should probably be notified about any PRs to the repo so let's just wildcard it for now and we can change it later if it makes sense.