### PR TITLE
Correct CODEOWNERS username casing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files in this repository
-* @shopify/functions-dependabot-reviewers
+* @Shopify/functions-dependabot-reviewers


### PR DESCRIPTION
The org has capital `S` in Shopify